### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To build and run the Chrome extension from this code:
 ```
 git clone https://github.com/PlebeianApp/plebeian-signer.git
 cd plebeian-signer
+npm install
 npm ci
 npm run build:chrome
 ```
@@ -48,6 +49,7 @@ To build and run the Firefox extension from this code:
 ```
 git clone https://github.com/PlebeianApp/plebeian-signer.git
 cd plebeian-signer
+npm install
 npm ci
 npm run build:firefox
 ```


### PR DESCRIPTION
Running the script as-is results in an installation error: `npm install` needs to be run first.

Error log:

```
git clone https://github.com/PlebeianApp/plebeian-signer.git
cd plebeian-signer
npm ci
npm run build:chrome
Cloning into 'plebeian-signer'...
remote: Enumerating objects: 2263, done.
remote: Counting objects: 100% (2263/2263), done.
remote: Compressing objects: 100% (866/866), done.
remote: Total 2263 (delta 1599), reused 2025 (delta 1361), pack-reused 0 (from 0)
Receiving objects: 100% (2263/2263), 22.78 MiB | 1.58 MiB/s, done.
Resolving deltas: 100% (1599/1599), done.
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'eslint-visitor-keys@5.0.1',
npm warn EBADENGINE   required: { node: '^20.19.0 || ^22.13.0 || >=24' },
npm warn EBADENGINE   current: { node: 'v23.11.0', npm: '10.9.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'espree@11.1.1',
npm warn EBADENGINE   required: { node: '^20.19.0 || ^22.13.0 || >=24' },
npm warn EBADENGINE   current: { node: 'v23.11.0', npm: '10.9.2' }
npm warn EBADENGINE }
npm error code EUSAGE
npm error
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error
```

When running `npm install` first, the issue is resolved. Therefore I'm proposing to update the instructions to reflect the working instructions.